### PR TITLE
Fix issue with missing comma for additional hooks

### DIFF
--- a/src/hook_smith/blueprint.clj
+++ b/src/hook_smith/blueprint.clj
@@ -116,10 +116,19 @@
              :qualifier "order_number"
              :keyset "source.order.order_number"
              :business_key_field "order_number"
-             :expression "SubField([order_number], '-', 1)"}]
+             :expression "SubField([order_number], '-', 1)"}
+            {:name "hook__order__line_number"
+             :primary false
+             :concept "order"
+             :qualifier "line_number"
+             :keyset "source.order.line_number"
+             :business_key_field "line_number"}]
     :composite_hooks [{:name "hook__order__product__id"
                        :primary true
-                       :hooks ["hook__order__id" "hook__product__id"]}]}
+                       :hooks ["hook__order__id" "hook__product__id"]}
+                      {:name "hook__order_number__line__id"
+                       :primary false
+                       :hooks ["hook__order__order_number" "hook__order__line_number"]}]}
    {:name "source__customer_orders"
     :skip_generation true
     :source_system "source"

--- a/src/hook_smith/frame.clj
+++ b/src/hook_smith/frame.clj
@@ -43,7 +43,7 @@
                                       (str "\t" (str/join " & '~' & " hook-refs) "\tAs [" name "]")))
                                   composite-hooks)]
       (when (seq composite-sections)
-        (str (str/join "\n" composite-sections)
+        (str (str/join "\n," composite-sections)
              "\n,\t*"
              "\n;\n\nLoad\n")))))
 

--- a/test/fixtures/documentation.md
+++ b/test/fixtures/documentation.md
@@ -50,6 +50,7 @@ flowchart LR
         hook__order__id
         hook__product__id
         hook__order__order_number
+        hook__order__line_number
         &nbsp;
         **Fields:**
         ...

--- a/test/fixtures/frames.yaml
+++ b/test/fixtures/frames.yaml
@@ -89,12 +89,25 @@
     business_key_field: order_number
     expression: SubField([order_number], '-', 1)
 
+  - name: hook__order__line_number
+    primary: false
+    concept: order
+    qualifier: line_number
+    keyset: source.order.line_number
+    business_key_field: line_number
+
   composite_hooks:
   - name: hook__order__product__id
     primary: true
     hooks:
     - hook__order__id
     - hook__product__id
+
+  - name: hook__order_number__line__id
+    primary: false
+    hooks:
+    - hook__order__order_number
+    - hook__order__line_number
 
 - name: source__customer_orders
   skip_generation: true

--- a/test/fixtures/hook.qvs
+++ b/test/fixtures/hook.qvs
@@ -80,6 +80,7 @@ Target: lib://adss/dab/source/frame__source__order_lines.qvd
 [source__order_lines]:
 Load
 	[hook__order__id] & '~' & [hook__product__id]	As [hook__order__product__id]
+,	[hook__order__order_number] & '~' & [hook__order__line_number]	As [hook__order_number__line__id]
 ,	*
 ;
 
@@ -87,6 +88,7 @@ Load
 	If(Not IsNull(Text([order_id])), 'source.order.id' & Text([order_id]))	As [hook__order__id]
 ,	If(Not IsNull(Text([product_id])), 'source.product.id' & Text([product_id]))	As [hook__product__id]
 ,	If(Not IsNull(SubField([order_number], '-', 1)), 'source.order.order_number' & SubField([order_number], '-', 1))	As [hook__order__order_number]
+,	If(Not IsNull(Text([line_number])), 'source.order.line_number' & Text([line_number]))	As [hook__order__line_number]
 ,	*
 
 From

--- a/test/fixtures/unified-star-schema.qvs
+++ b/test/fixtures/unified-star-schema.qvs
@@ -361,6 +361,7 @@ Load
 ,	[hook__order__id]
 ,	[hook__product__id]
 ,	[hook__order__order_number]
+,	[hook__order__line_number]
 ,	[Record Valid From (source__order_lines)]
 ,	[Record Valid To (source__order_lines)]
 


### PR DESCRIPTION
Fix issue with missing comma for additional hooks.

Specifically, it:

- Includes documentation and fixture updates for the new example hook.
- Fixes a formatting issue with composite hook definitions by adding a missing comma.