### PR TITLE
Updates documentation with composite hook

### DIFF
--- a/src/hook_smith/documentation.clj
+++ b/src/hook_smith/documentation.clj
@@ -10,8 +10,11 @@
 
 (defn get-foreign-key-hooks [frame]
   (let [hooks (get frame :hooks [])
-        non-primary-hooks (filter #(not (true? (:primary %))) hooks)]
-    (map :name non-primary-hooks)))
+        composite-hooks (get frame :composite_hooks [])
+        non-primary-hooks (filter #(not (true? (:primary %))) hooks)
+        non-primary-composite-hooks (filter #(not (true? (:primary %))) composite-hooks)]
+    (concat (map :name non-primary-hooks)
+            (map :name non-primary-composite-hooks))))
 
 (defn generate-hook-entity-block [frame]
   (let [frame-name (:name frame)

--- a/test/fixtures/documentation.md
+++ b/test/fixtures/documentation.md
@@ -48,6 +48,7 @@ flowchart LR
         hook__product__id
         hook__order__order_number
         hook__order__line_number
+        hook__order_number__line__id
         &nbsp;
         **Fields:**
         ...


### PR DESCRIPTION
Updates the documentation fixture.

- Adds an example of a foreign composite hook to the documentation.
- This ensures the documentation accurately reflects the functionality by including a composite key example.